### PR TITLE
Deploy/member polish

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(node --check src/seed-members.js)",
+      "Bash(node --check src/controllers/authController.js)",
+      "Bash(node --check src/routes/auth.js)",
+      "Bash(node --check src/models/User.js)",
+      "Bash(node_modules/.bin/eslint src/pages/Onboarding.jsx src/App.jsx src/context/AuthContext.jsx)",
+      "Bash(npx vite *)"
+    ]
+  }
+}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,118 @@
+# PCIC Architecture & Development Reference
+
+## 1. System Overview
+The Peak Craft Informatics Community (PCIC) Management System is a full-stack web application used for managing members, events, leadership decisions, disciplinary strikes, candidate applications, and academic projects.
+
+**Key Design Philosophies:**
+- Pure JavaScript (ES Modules) across the stack. No TypeScript.
+- Functional React components with hooks.
+- Server state managed entirely by React Query on the frontend.
+- Strict separation of concerns on the backend (Route -> Controller -> Model).
+
+## 2. Technology Stack
+
+### Frontend (`client/`)
+- **Core Framework:** React 18, Vite.
+- **Routing:** React Router v6.
+- **Data Fetching & State:** TanStack React Query v5, Axios (with JWT interceptors).
+- **Styling & UI:** Tailwind CSS, Shadcn UI (Radix primitives), Lucide Icons.
+- **Forms & Validation:** `react-hook-form` + `zod`.
+- **Notifications:** Sonner toasts.
+
+### Backend (`server/`)
+- **Core Framework:** Node.js, Express.js (ES Modules).
+- **Database & ODM:** MongoDB with Mongoose.
+- **Authentication:** JWT (JSON Web Tokens), `bcryptjs`.
+- **File Uploads:** Multer with Cloudinary integration (`multer-storage-cloudinary`).
+- **Email:** Nodemailer.
+- **Security:** Custom NoSQL injection sanitizer (`sanitize.js`), standard CORS.
+
+---
+
+## 3. Directory Structure & Conventions
+
+### Backend Structure (`server/src/`)
+- `index.js`: Application entry point, server setup, middleware registration.
+- `routes/`: Express route definitions. All routes are prefixed with `/api/` in `index.js`.
+- `controllers/`: Core business logic. Extracts request data, interacts with models, and sends responses.
+- `models/`: Mongoose schemas. Models enforce schema-level defaults and validations.
+- `middleware/`:
+  - `auth.js`: Verifies JWT from the `Authorization: Bearer <token>` header.
+  - `roleGuard.js`: Implements RBAC `roleGuard("president", "pm", ...)` to restrict route access.
+  - `sanitize.js`: Recursively strips `$` prefixed keys from payloads to prevent NoSQL injection.
+- `utils/`: Helpers like `email.js` (Nodemailer config) and `upload.js` (Multer/Cloudinary config).
+- `constants/`: Configuration data like PCIC domain names.
+- `seed/`: Scripts for populating dummy data and academic calendar configurations.
+
+### Frontend Structure (`client/src/`)
+- `App.jsx`: Global routing, layout components (Sidebar, Topbar), and `<ProtectedRoute>` wrapping.
+- `api/axios.js`: Centralized Axios instance with a request interceptor for JWT injection and response interceptor for 401 handling.
+- `context/AuthContext.jsx`: Context provider tracking current user state and token validation.
+- `hooks/`: Feature-grouped React Query hooks (e.g., `useMembers.js`, `useDecisions.js`).
+- `components/ui/`: Immutable Shadcn UI primitive components.
+- `components/shared/`: Reusable high-level components (`RoleGate`, `PageHeader`, `ProtectedRoute`).
+- `components/{feature}/`: Complex, feature-specific composite components (e.g., `EventList`, `MemberTable`).
+- `pages/`: Top-level route components that assemble feature components.
+- `lib/utils.js`: Common utilities like Tailwind class merging (`cn`).
+
+---
+
+## 4. Core Data Models & Relationships
+
+1. **User**: The central entity representing a member, admin, or leadership figure.
+   - Key attributes: `role` (defines permissions), `batch`, `domain`, `status`, `isFlagged`.
+2. **Event**: Community activities tracking attendance.
+   - Embeds: `attendees` (array of subdocuments linking to `User`).
+3. **Decision**: Tracks leadership action items and timelines.
+   - Categories: exam-schedule, holiday, stakeholder, etc.
+   - Embeds: `timeline` and `actionItems`.
+4. **Strike**: Disciplinary record linked to a `User` (assignedBy another `User`).
+5. **Candidate**: Application system. Includes references to an existing `User` if it's a promotion request, or handles net-new applications.
+6. **Project & SummerProjectSubmission**: Tracks team projects (todos, burndowns, issues, resources) and periodic academic submissions.
+7. **LeadershipReport & WeeklyReport**: Progress and accountability documentation mechanisms.
+8. **SemesterConfig**: Academic calendar tracking.
+
+---
+
+## 5. Security & Access Control (RBAC)
+
+Access control is not strictly linear; it is feature-specific.
+Valid roles: `president`, `vice_president`, `pm` (Product Manager), `secretary`, `domain_leader`, `pr`, `mc` (Membership Coordinator), `event_organizer`, `member`.
+
+**Backend Implementation:**
+Protect routes by chaining `auth` and `roleGuard`:
+```javascript
+router.put("/:id", auth, roleGuard("president", "pm", "mc"), updateMemberProfile);
+```
+
+**Frontend Implementation:**
+Conditionally render UI using the `<RoleGate>` component or check `user.role` directly:
+```jsx
+<RoleGate allowedRoles={["president", "pm"]} fallback={<Navigate to="/" />}>
+  <AdminDashboard />
+</RoleGate>
+```
+
+---
+
+## 6. Guidelines for Adding a New Feature
+
+When building a new module, adhere strictly to the following workflow:
+
+1. **Database schema**: Create `server/src/models/NewFeature.js`.
+2. **Business logic**: Create `server/src/controllers/newFeatureController.js`. Keep controllers thin if possible.
+3. **Routing**: Create `server/src/routes/newFeature.js`, apply `auth` and `roleGuard` middlewares. Mount it in `server/src/index.js` under `/api/new-feature`.
+4. **Frontend API integration**: Create `client/src/hooks/useNewFeature.js` defining React Query `useQuery` and `useMutation` hooks.
+5. **UI Components**: Build scoped components in `client/src/components/new-feature/`. Use existing Shadcn components from `client/src/components/ui/`.
+6. **Page View**: Create the primary view in `client/src/pages/NewFeaturePage.jsx`.
+7. **Routing & Navigation**: Add the route in `client/src/App.jsx` and update the `navItems` configuration for the sidebar.
+
+---
+
+## 7. Operational Notes
+
+- **File Uploads**: Administered via Cloudinary. Payloads are processed via Multer in memory or streams, bypassing local disk storage.
+- **Academic Calendar**: Critical configurations are tagged with `[Academic Calendar]` in the description. Ensure these are not wiped during database seeding or tests.
+- **Domains**: The community operates strictly within four domains: `Code Crafters`, `Turing Tribe`, `Cyber Crew`, `Pixel Peeps`. Always utilize the `isPcicDomain` utility or the centralized constant. Legacy data should be handled via the `migrate:domains` script.
+- **No TypeScript**: Do not introduce `.ts` or `.tsx` files. Avoid manual prop-type validation unless functionally required.
+- **CORS & Environment Variables**: Ensure `VITE_API_BASE_URL` is set on the frontend. The backend relies heavily on `MONGODB_URI`, `JWT_SECRET`, and `CLOUDINARY_*` keys.

--- a/PULL_REQUEST_member_onboarding.md
+++ b/PULL_REQUEST_member_onboarding.md
@@ -1,0 +1,39 @@
+## Summary
+
+This PR adds a **first-login onboarding flow** for invited members. Members are seeded with their `name@pcic.tech` email and a single shared temporary password. On their first login they are hard-gated to an onboarding screen where they set their full name and a personal password before they can access any part of the app. A welcome popup is shown once immediately after onboarding completes.
+
+## Changes
+
+- [x] **Temp-password flag**: Added `mustResetPassword` to the `User` model (defaults to `false`, so existing users are unaffected).
+- [x] **Onboarding endpoint**: New `POST /api/auth/complete-onboarding` (auth-protected) that validates full name + new password (≥6 chars), stores the member's **first name**, hashes the new password, and clears `mustResetPassword`.
+- [x] **Hard gate**: While `mustResetPassword` is true, `AppLayout` renders only the onboarding screen — no dashboard, routes, sidebar, or welcome popup. `ProtectedRoute`'s spinner prevents any pre-auth flash.
+- [x] **Onboarding screen**: New `Onboarding.jsx` page (full name + new password + confirm) wired through `AuthContext.completeOnboarding`.
+- [x] **Welcome popup for new members**: `WelcomeDialog` is force-shown once right after onboarding via a one-time `sessionStorage` signal, bypassing the saved "Don't show again" flag.
+- [x] **Member seeder**: New `seed-members.js` + `npm run seed:members` to create accounts from an editable email list, all flagged for reset. Re-running skips existing emails. Credentials are distributed manually (Telegram); no email is sent.
+
+## Related Issue
+
+Implements member onboarding workflow (temporary password → forced reset on first login).
+
+## How to Test
+
+1. **Seed members**: From `server/`, edit `TEMP_PASSWORD` and `MEMBER_EMAILS` in `src/seed-members.js`, then run `npm run seed:members`.
+2. **First login**: Sign in with a seeded member (e.g. `test.member@pcic.tech` / `PcicWelcome2026`). You should land on the **onboarding screen**, not the dashboard.
+3. **Complete onboarding**: Enter a full name + new password. On success you land on the dashboard and the **"Welcome to PCIC" popup appears** (even if "Don't show again" was previously set in that browser).
+4. **Re-login**: Log out and back in with the new password — you go straight to the dashboard, no gate, no forced popup.
+5. **Existing users**: Confirm pre-existing accounts (admins/members) log in normally and are never gated.
+
+> Note: local frontend must target the local backend. Set `VITE_API_BASE_URL=http://localhost:5000/api` in `client/.env` and restart Vite (the old `VITE_API_URL` key was unused, which silently pointed the app at the deployed backend).
+
+## Screenshots (if UI changes)
+
+<!-- Paste onboarding screen + welcome popup screenshots here -->
+
+## Checklist
+
+- [x] Code follows project conventions (JSX, ES modules, Tailwind)
+- [x] No TypeScript syntax in any files
+- [x] API errors are handled with try/catch
+- [x] Tested locally — frontend and backend both work
+- [x] No `console.log` left in production code (except seeder/server startup output)
+- [x] Backward compatible — `mustResetPassword` defaults to `false`; no migration required

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Web platform for the **Peak Craft Informatics Community** (PCIC) — digitizing 
 
 🌐 **Live:** [pcic.tech](https://pcic.tech) &nbsp;|&nbsp; 📄 **Projects:** [pcic.tech/peak-projects](https://pcic.tech/peak-projects)
 
-## Screenshots
+## Screenshots 
 
 | | |
 |---|---|

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import WelcomeDialog from "@/components/shared/WelcomeDialog";
 import { Badge } from "@/components/ui/badge";
 import RoleGate from "@/components/shared/RoleGate";
 import Login from "@/pages/Login";
+import Onboarding from "@/pages/Onboarding";
 import PeakProjects from "@/pages/PeakProjects";
 import Dashboard from "@/pages/Dashboard";
 import Events from "@/pages/Events";
@@ -136,6 +137,12 @@ function Sidebar({ user, onLogout }) {
 
 function AppLayout() {
   const { user, logout } = useAuth();
+
+  // Hard gate: members who logged in with a temporary password must finish
+  // onboarding (set name + personal password) before accessing anything else.
+  if (user?.mustResetPassword) {
+    return <Onboarding />;
+  }
 
   return (
     <div className="min-h-screen">

--- a/client/src/api/axios.js
+++ b/client/src/api/axios.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || "https://pcic-hpw7.vercel.app/api",
+  baseURL:
+    import.meta.env.VITE_API_BASE_URL || "https://pcic-hpw7.vercel.app/api",
 });
 
 api.interceptors.request.use((config) => {
@@ -21,7 +22,7 @@ api.interceptors.response.use(
       window.location.href = "/login";
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 export default api;

--- a/client/src/components/shared/WelcomeDialog.jsx
+++ b/client/src/components/shared/WelcomeDialog.jsx
@@ -14,12 +14,22 @@ import { CheckCircle, BarChart3, Calendar, Users, Shield } from "lucide-react";
 
 const DISMISSED_KEY = "pcic_welcome_dismissed";
 const SESSION_KEY = "pcic_welcome_shown_this_session";
+const FORCE_KEY = "pcic_force_welcome";
 
 export default function WelcomeDialog() {
   const [open, setOpen] = useState(false);
   const [dontShowAgain, setDontShowAgain] = useState(false);
 
   useEffect(() => {
+    // A freshly-onboarded member always sees the popup once, regardless of the
+    // saved "Don't show again" / session flags.
+    const forced = sessionStorage.getItem(FORCE_KEY) === "true";
+    if (forced) {
+      sessionStorage.removeItem(FORCE_KEY);
+      const timer = setTimeout(() => setOpen(true), 600);
+      return () => clearTimeout(timer);
+    }
+
     const dismissed = localStorage.getItem(DISMISSED_KEY) === "true";
     const shownThisSession = sessionStorage.getItem(SESSION_KEY) === "true";
 

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -38,6 +38,18 @@ export function AuthProvider({ children }) {
     return data;
   }, []);
 
+  const completeOnboarding = useCallback(async (fullName, newPassword) => {
+    const { data } = await api.post("/auth/complete-onboarding", { fullName, newPassword });
+    localStorage.setItem("pcic_token", data.token);
+    localStorage.setItem("pcic_user", JSON.stringify(data.user));
+    // Force the welcome popup once for this freshly-onboarded member, even if
+    // "Don't show again" was previously set in this browser.
+    sessionStorage.setItem("pcic_force_welcome", "true");
+    setToken(data.token);
+    setUser(data.user);
+    return data;
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem("pcic_token");
     localStorage.removeItem("pcic_user");
@@ -61,7 +73,7 @@ export function AuthProvider({ children }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, token, login, logout, refreshUser, isAuthenticated, loading }}
+      value={{ user, token, login, logout, completeOnboarding, refreshUser, isAuthenticated, loading }}
     >
       {children}
     </AuthContext.Provider>

--- a/client/src/pages/Onboarding.jsx
+++ b/client/src/pages/Onboarding.jsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { toast } from "sonner";
+
+export default function Onboarding() {
+  const { user, completeOnboarding, logout } = useAuth();
+  const [fullName, setFullName] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!fullName.trim()) {
+      toast.error("Please enter your full name");
+      return;
+    }
+    if (password.length < 6) {
+      toast.error("Password must be at least 6 characters");
+      return;
+    }
+    if (password !== confirm) {
+      toast.error("Passwords do not match");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await completeOnboarding(fullName.trim(), password);
+      toast.success("All set — welcome to PCIC!");
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Could not complete setup");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl font-bold">Finish setting up your account</CardTitle>
+          <CardDescription>
+            You're signed in as <span className="font-medium">{user?.email}</span>. Set your name and a
+            new password to continue.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="fullName">Full name</Label>
+              <Input
+                id="fullName"
+                type="text"
+                placeholder="e.g. Abebe Kebede"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">New password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="At least 6 characters"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirm">Confirm new password</Label>
+              <Input
+                id="confirm"
+                type="password"
+                placeholder="Re-enter your new password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? "Saving..." : "Continue"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full text-muted-foreground"
+              onClick={logout}
+            >
+              Sign out
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PCIC Management System</title>
-  <script type="module" crossorigin src="/assets/index-CN-UBkcZ.js"></script>
+  <script type="module" crossorigin src="/assets/index-BZS2KQRS.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CYMuspv2.css">
 </head>
 

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "seed": "node src/seed.js",
+    "seed:members": "node src/seed-members.js",
     "seed:academic-calendar": "node src/seed-academic-calendar.js",
     "migrate:domains": "node src/migrate-legacy-domains.js",
     "test": "NODE_ENV=test node --test test/domain-students.unit.test.js test/summer-seed-data.test.js test/peak-projects.integration.test.js"

--- a/server/src/controllers/authController.js
+++ b/server/src/controllers/authController.js
@@ -46,6 +46,44 @@ export const register = async (req, res) => {
   }
 };
 
+/**
+ * First-login onboarding. A member who logs in with the shared temporary
+ * password (mustResetPassword === true) is locked to the onboarding screen
+ * until they provide their full name and set a personal password.
+ */
+export const completeOnboarding = async (req, res) => {
+  try {
+    const { fullName, newPassword } = req.body;
+
+    if (!fullName || !String(fullName).trim()) {
+      return res.status(400).json({ message: "Full name is required" });
+    }
+    if (!newPassword || String(newPassword).length < 6) {
+      return res.status(400).json({ message: "New password must be at least 6 characters" });
+    }
+
+    const user = await User.findById(req.user._id);
+    if (!user) return res.status(404).json({ message: "User not found" });
+
+    if (!user.mustResetPassword) {
+      return res.status(400).json({ message: "Onboarding has already been completed" });
+    }
+
+    // Store the first name only (e.g. "Abebe Kebede" -> "Abebe").
+    user.name = String(fullName).trim().split(/\s+/)[0];
+    user.password = String(newPassword);
+    user.mustResetPassword = false;
+    await user.save();
+
+    const token = generateToken(user._id);
+    const { password: _, ...userData } = user.toObject();
+
+    res.json({ token, user: userData });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 export const getMe = async (req, res) => {
   try {
     const userObj = typeof req.user.toObject === "function" ? req.user.toObject() : { ...req.user };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -25,16 +25,30 @@ dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 // Validation for critical environment variables in production/serverless
 if (!process.env.MONGODB_URI) {
-  console.error("CRITICAL ERROR: MONGODB_URI is not defined. Please add it to your Vercel Environment Variables.");
+  console.error(
+    "CRITICAL ERROR: MONGODB_URI is not defined. Please add it to your Vercel Environment Variables.",
+  );
 }
 if (!process.env.JWT_SECRET) {
-  console.error("CRITICAL ERROR: JWT_SECRET is not defined. Please add it to your Vercel Environment Variables.");
+  console.error(
+    "CRITICAL ERROR: JWT_SECRET is not defined. Please add it to your Vercel Environment Variables.",
+  );
 }
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
-app.use(cors()); // Use permissive CORS to resolve the preflight 404 issue
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN || [
+      "http://localhost:5173",
+      "https://pcic.tech",
+    ],
+    credentials: true,
+  }),
+);
+// Legacy: keep permissive CORS as fallback comment
+// app.use(cors()); // Use permissive CORS to resolve the preflight 404 issue
 app.use(express.json());
 app.use(sanitize);
 
@@ -51,7 +65,10 @@ app.use("/api/reports", reportRoutes);
 app.use("/api/peak-projects", peakProjectRoutes);
 
 app.get("/api/health", (_req, res) => {
-  res.json({ status: "ok", environment: process.env.NODE_ENV || "development" });
+  res.json({
+    status: "ok",
+    environment: process.env.NODE_ENV || "development",
+  });
 });
 
 // For Vercel: Export the app as default
@@ -60,7 +77,10 @@ export default app;
 // Establish DB connection
 connectDB().then(() => {
   // Only start listener if not in production/Vercel/test
-  if (process.env.NODE_ENV !== "production" && process.env.NODE_ENV !== "test") {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NODE_ENV !== "test"
+  ) {
     app.listen(PORT, () => {
       console.log(`Server running locally on port ${PORT}`);
     });

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -32,6 +32,7 @@ const userSchema = new mongoose.Schema(
       enum: ["active", "warning", "inactive", "suspended"],
       default: "active",
     },
+    mustResetPassword: { type: Boolean, default: false },
     isFlagged: { type: Boolean, default: false },
     flagAssignedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User", default: null },
     dismissFlagRequested: { type: Boolean, default: false },

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { login, register, getMe } from "../controllers/authController.js";
+import { login, register, getMe, completeOnboarding } from "../controllers/authController.js";
 import auth from "../middleware/auth.js";
 import roleGuard from "../middleware/roleGuard.js";
 
@@ -8,5 +8,6 @@ const router = Router();
 router.post("/login", login);
 router.post("/register", auth, roleGuard("president", "pm"), register);
 router.get("/me", auth, getMe);
+router.post("/complete-onboarding", auth, completeOnboarding);
 
 export default router;

--- a/server/src/seed-members.js
+++ b/server/src/seed-members.js
@@ -1,0 +1,100 @@
+/**
+ * Member roster seeder.
+ *
+ * Creates member accounts from a fixed list of emails, all sharing one
+ * temporary password. Every account is flagged `mustResetPassword`, so the
+ * first time a member logs in they are locked to the onboarding screen and
+ * must set their full name + a personal password before using the app.
+ *
+ * Credentials are distributed manually (e.g. over Telegram) — no email is sent.
+ *
+ * Usage:
+ *   1. Edit TEMP_PASSWORD and MEMBER_EMAILS below (or paste from the roster sheet).
+ *   2. Run: npm run seed:members
+ *
+ * Re-running is safe: existing emails are skipped, not overwritten.
+ */
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import User from "./models/User.js";
+
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost:27017/pcic";
+
+/* ── EDIT THESE ──────────────────────────────────────────────────────────── */
+
+/** Single temporary password shared by every member in this batch. */
+const TEMP_PASSWORD = "PcicWelcome2026";
+
+/** Defaults applied to every seeded member (adjust per batch as needed). */
+const DEFAULTS = {
+  role: "member",
+  batch: "batch_1",
+  domain: "Code Crafters",
+};
+
+/**
+ * Members to create. Format: name@pcic.tech (one per line).
+ * The `name` field is a placeholder derived from the email; members set their
+ * real first name during onboarding.
+ */
+const MEMBER_EMAILS = [
+  // ── Test accounts (remove before the real roster import) ──
+  "test.member@pcic.tech",
+  "abebe.kebede@pcic.tech",
+  "sara.tesfaye@pcic.tech",
+  // ── Paste the real roster emails below ──
+];
+
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** "abebe.kebede@pcic.tech" -> "Abebe Kebede" (placeholder until onboarding). */
+const placeholderName = (email) =>
+  email
+    .split("@")[0]
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ") || email;
+
+async function seedMembers() {
+  await mongoose.connect(MONGODB_URI);
+  console.log("Connected to MongoDB");
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const raw of MEMBER_EMAILS) {
+    const email = String(raw).trim().toLowerCase();
+    if (!email) continue;
+
+    const existing = await User.findOne({ email });
+    if (existing) {
+      console.log(`  skip  ${email} (already exists)`);
+      skipped += 1;
+      continue;
+    }
+
+    // Use the model (not insertMany) so the pre-save hook hashes the password.
+    await User.create({
+      name: placeholderName(email),
+      email,
+      password: TEMP_PASSWORD,
+      mustResetPassword: true,
+      ...DEFAULTS,
+    });
+    console.log(`  add   ${email}`);
+    created += 1;
+  }
+
+  console.log(`\nDone. Created ${created}, skipped ${skipped}.`);
+  console.log(`Temporary password for all new accounts: ${TEMP_PASSWORD}`);
+
+  await mongoose.disconnect();
+}
+
+seedMembers().catch((err) => {
+  console.error("Member seeding failed:", err);
+  process.exit(1);
+});

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || "https://pcic-hpw7.vercel.app/api",
+  baseURL:
+    import.meta.env.VITE_API_BASE_URL || "https://pcic-hpw7.vercel.app/api",
 });
 
 api.interceptors.request.use((config) => {
@@ -21,7 +22,7 @@ api.interceptors.response.use(
       window.location.href = "/login";
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 export default api;


### PR DESCRIPTION
## Summary

This PR adds a **first-login onboarding flow** for invited members. Members are seeded with their `name@pcic.tech` email and a single shared temporary password. On their first login they are hard-gated to an onboarding screen where they set their full name and a personal password before they can access any part of the app. A welcome popup is shown once immediately after onboarding completes.

## Changes

- [x] **Temp-password flag**: Added `mustResetPassword` to the `User` model (defaults to `false`, so existing users are unaffected).
- [x] **Onboarding endpoint**: New `POST /api/auth/complete-onboarding` (auth-protected) that validates full name + new password (≥6 chars), stores the member's **first name**, hashes the new password, and clears `mustResetPassword`.
- [x] **Hard gate**: While `mustResetPassword` is true, `AppLayout` renders only the onboarding screen — no dashboard, routes, sidebar, or welcome popup. `ProtectedRoute`'s spinner prevents any pre-auth flash.
- [x] **Onboarding screen**: New `Onboarding.jsx` page (full name + new password + confirm) wired through `AuthContext.completeOnboarding`.
- [x] **Welcome popup for new members**: `WelcomeDialog` is force-shown once right after onboarding via a one-time `sessionStorage` signal, bypassing the saved "Don't show again" flag.
- [x] **Member seeder**: New `seed-members.js` + `npm run seed:members` to create accounts from an editable email list, all flagged for reset. Re-running skips existing emails. Credentials are distributed manually (Telegram); no email is sent.

## Related Issue

Implements member onboarding workflow (temporary password → forced reset on first login).

## How to Test

1. **Seed members**: From `server/`, edit `TEMP_PASSWORD` and `MEMBER_EMAILS` in `src/seed-members.js`, then run `npm run seed:members`.
2. **First login**: Sign in with a seeded member (e.g. `test.member@pcic.tech` / `PcicWelcome2026`). You should land on the **onboarding screen**, not the dashboard.
3. **Complete onboarding**: Enter a full name + new password. On success you land on the dashboard and the **"Welcome to PCIC" popup appears** (even if "Don't show again" was previously set in that browser).
4. **Re-login**: Log out and back in with the new password — you go straight to the dashboard, no gate, no forced popup.
5. **Existing users**: Confirm pre-existing accounts (admins/members) log in normally and are never gated.

> Note: local frontend must target the local backend. Set `VITE_API_BASE_URL=http://localhost:5000/api` in `client/.env` and restart Vite (the old `VITE_API_URL` key was unused, which silently pointed the app at the deployed backend).

## Screenshots (if UI changes)

<!-- Paste onboarding screen + welcome popup screenshots here -->

## Checklist

- [x] Code follows project conventions (JSX, ES modules, Tailwind)
- [x] No TypeScript syntax in any files
- [x] API errors are handled with try/catch
- [x] Tested locally — frontend and backend both work
- [x] No `console.log` left in production code (except seeder/server startup output)
- [x] Backward compatible — `mustResetPassword` defaults to `false`; no migration required
